### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/rcore-os/pie-boot/security/code-scanning/1](https://github.com/rcore-os/pie-boot/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to the repository contents (e.g., for `actions/checkout@v4`), we can set `contents: read` as the minimal permission. This ensures the `GITHUB_TOKEN` has the least privilege necessary to complete the task.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to limit permissions specifically for that job. In this case, adding it at the root level is sufficient and simplifies the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
