### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "kasm-aarch64"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "kdef-pgtable"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitflags",
  "prettyplease",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "abi-singleton",
  "darling",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/kdef-pgtable/CHANGELOG.md
+++ b/kdef-pgtable/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.0...kdef-pgtable-v0.1.1) - 2025-06-14
+
+### Other
+
+- init

--- a/kdef-pgtable/Cargo.toml
+++ b/kdef-pgtable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kdef-pgtable"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 categories.workspace = true

--- a/loader/pie-boot-loader-macros/CHANGELOG.md
+++ b/loader/pie-boot-loader-macros/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-macros-v0.1.0...pie-boot-loader-macros-v0.1.1) - 2025-06-14
+
+### Other
+
+- init

--- a/loader/pie-boot-loader-macros/Cargo.toml
+++ b/loader/pie-boot-loader-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pie-boot-loader-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 categories.workspace = true

--- a/pie-boot/macros/kasm-aarch64/CHANGELOG.md
+++ b/pie-boot/macros/kasm-aarch64/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/rcore-os/pie-boot/compare/kasm-aarch64-v0.1.0...kasm-aarch64-v0.1.1) - 2025-06-14
+
+### Other
+
+- init

--- a/pie-boot/macros/kasm-aarch64/Cargo.toml
+++ b/pie-boot/macros/kasm-aarch64/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.0"
+version = "0.1.1"
 
 [lib]
 proc-macro = true

--- a/pie-boot/macros/pie-boot-macros/CHANGELOG.md
+++ b/pie-boot/macros/pie-boot-macros/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/rcore-os/pie-boot/compare/pie-boot-macros-v0.1.0...pie-boot-macros-v0.1.1) - 2025-06-14
+
+### Other
+
+- init

--- a/pie-boot/macros/pie-boot-macros/Cargo.toml
+++ b/pie-boot/macros/pie-boot-macros/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.0"
+version = "0.1.1"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION



## 🤖 New release

* `kdef-pgtable`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `pie-boot-macros`: 0.1.0 -> 0.1.1
* `kasm-aarch64`: 0.1.0 -> 0.1.1
* `pie-boot-loader-macros`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `kdef-pgtable`

<blockquote>

## [0.1.1](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.0...kdef-pgtable-v0.1.1) - 2025-06-14

### Other

- init
</blockquote>

## `pie-boot-macros`

<blockquote>

## [0.1.1](https://github.com/rcore-os/pie-boot/compare/pie-boot-macros-v0.1.0...pie-boot-macros-v0.1.1) - 2025-06-14

### Other

- init
</blockquote>

## `kasm-aarch64`

<blockquote>

## [0.1.1](https://github.com/rcore-os/pie-boot/compare/kasm-aarch64-v0.1.0...kasm-aarch64-v0.1.1) - 2025-06-14

### Other

- init
</blockquote>

## `pie-boot-loader-macros`

<blockquote>

## [0.1.1](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-macros-v0.1.0...pie-boot-loader-macros-v0.1.1) - 2025-06-14

### Other

- init
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).