### PR TITLE
chore: release v0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "bindeps-simple",
  "kasm-aarch64",
@@ -982,7 +982,7 @@ version = "0.1.1"
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aarch64-cpu",
  "any-uart",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.7...pie-boot-loader-aarch64-v0.1.8) - 2025-06-15
+
+### Other
+
+- 明确crate构建目标
+
 ## [0.1.7](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.6...pie-boot-loader-aarch64-v0.1.7) - 2025-06-14
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.7"
+version = "0.1.8"
 
 [features]
 console = ["dep:any-uart"]

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.1.7...pie-boot-v0.1.8) - 2025-06-15
+
+### Other
+
+- 明确crate构建目标
+
 ## [0.1.7](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.1.6...pie-boot-v0.1.7) - 2025-06-14
 
 ### Added

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.1.7"
+version = "0.1.8"
 
 [features]
 hv = []


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-loader-aarch64`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
* `pie-boot`: 0.1.7 -> 0.1.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.8](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.7...pie-boot-loader-aarch64-v0.1.8) - 2025-06-15

### Other

- 明确crate构建目标
</blockquote>

## `pie-boot`

<blockquote>

## [0.1.8](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.1.7...pie-boot-v0.1.8) - 2025-06-15

### Other

- 明确crate构建目标
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).