### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "bindeps-simple",
  "kasm-aarch64",
@@ -978,11 +978,11 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-if"
-version = "0.1.1"
+version = "0.2.0"
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "aarch64-cpu",
  "any-uart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ version = "0.1.0"
 [workspace.dependencies]
 kasm-aarch64 = {path = "macros/kasm-aarch64", version = "0.1"}
 kdef-pgtable = {path = "kdef-pgtable", version = "0.1"}
-pie-boot-if = {path = "pie-boot-if", version = "0.1.1"}
+pie-boot-if = {path = "pie-boot-if", version = "0.2.0" }
 pie-boot-loader-macros = {path = "loader/pie-boot-loader-macros", version = "0.1"}
 pie-boot-macros = {path = "macros/pie-boot-macros", version = "0.1"}

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.8...pie-boot-loader-aarch64-v0.1.9) - 2025-06-17
+
+### Other
+
+- remove unused macros and clean up console module; update BootArgs struct to include kernel image addresses
+
 ## [0.1.8](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.7...pie-boot-loader-aarch64-v0.1.8) - 2025-06-15
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.8"
+version = "0.1.9"
 
 [features]
 console = ["dep:any-uart"]

--- a/pie-boot-if/CHANGELOG.md
+++ b/pie-boot-if/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.1.1...pie-boot-if-v0.2.0) - 2025-06-17
+
+### Other
+
+- remove unused macros and clean up console module; update BootArgs struct to include kernel image addresses

--- a/pie-boot-if/Cargo.toml
+++ b/pie-boot-if/Cargo.toml
@@ -7,6 +7,6 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-if"
 repository.workspace = true
-version = "0.1.1"
+version = "0.2.0"
 
 [dependencies]

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.1.8...pie-boot-v0.1.9) - 2025-06-17
+
+### Other
+
+- updated the following local packages: pie-boot-if
+
 ## [0.1.8](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.1.7...pie-boot-v0.1.8) - 2025-06-15
 
 ### Other

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.1.8"
+version = "0.1.9"
 
 [features]
 hv = []


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-if`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `pie-boot-loader-aarch64`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `pie-boot`: 0.1.8 -> 0.1.9

### ⚠ `pie-boot-if` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BootArgs.kimage_start_lma in /tmp/.tmpLAd22n/pie-boot/pie-boot-if/src/lib.rs:33
  field BootArgs.kimage_start_vma in /tmp/.tmpLAd22n/pie-boot/pie-boot-if/src/lib.rs:35
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-if`

<blockquote>

## [0.2.0](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.1.1...pie-boot-if-v0.2.0) - 2025-06-17

### Other

- remove unused macros and clean up console module; update BootArgs struct to include kernel image addresses
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.9](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.8...pie-boot-loader-aarch64-v0.1.9) - 2025-06-17

### Other

- remove unused macros and clean up console module; update BootArgs struct to include kernel image addresses
</blockquote>

## `pie-boot`

<blockquote>

## [0.1.9](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.1.8...pie-boot-v0.1.9) - 2025-06-17

### Other

- updated the following local packages: pie-boot-if
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).