### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "kasm-aarch64"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -983,7 +983,7 @@ version = "0.2.0"
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aarch64-cpu",
  "any-uart",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.9...pie-boot-loader-aarch64-v0.1.10) - 2025-06-17
+
+### Fixed
+
+- pte add cache for codes
+
 ## [0.1.9](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.8...pie-boot-loader-aarch64-v0.1.9) - 2025-06-17
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.9"
+version = "0.1.10"
 
 [features]
 console = ["dep:any-uart"]

--- a/macros/kasm-aarch64/CHANGELOG.md
+++ b/macros/kasm-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/rcore-os/pie-boot/compare/kasm-aarch64-v0.1.1...kasm-aarch64-v0.1.2) - 2025-06-17
+
+### Fixed
+
+- pte add cache for codes
+
 ## [0.1.1](https://github.com/rcore-os/pie-boot/compare/kasm-aarch64-v0.1.0...kasm-aarch64-v0.1.1) - 2025-06-14
 
 ### Other

--- a/macros/kasm-aarch64/Cargo.toml
+++ b/macros/kasm-aarch64/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION



## 🤖 New release

* `kasm-aarch64`: 0.1.1 -> 0.1.2
* `pie-boot-loader-aarch64`: 0.1.9 -> 0.1.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `kasm-aarch64`

<blockquote>

## [0.1.2](https://github.com/rcore-os/pie-boot/compare/kasm-aarch64-v0.1.1...kasm-aarch64-v0.1.2) - 2025-06-17

### Fixed

- pte add cache for codes
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.10](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.9...pie-boot-loader-aarch64-v0.1.10) - 2025-06-17

### Fixed

- pte add cache for codes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).