### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "bindeps-simple",
  "fdt-parser",
@@ -1017,11 +1017,11 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-if"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aarch64-cpu",
  "any-uart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ version = "0.1.0"
 [workspace.dependencies]
 kasm-aarch64 = {path = "macros/kasm-aarch64", version = "0.1"}
 kdef-pgtable = {path = "kdef-pgtable", version = "0.1"}
-pie-boot-if = {path = "pie-boot-if", version = "0.3.0" }
+pie-boot-if = {path = "pie-boot-if", version = "0.4.0" }
 pie-boot-loader-macros = {path = "loader/pie-boot-loader-macros", version = "0.1"}
 pie-boot-macros = {path = "macros/pie-boot-macros", version = "0.1"}

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.11...pie-boot-loader-aarch64-v0.1.12) - 2025-06-19
+
+### Other
+
+- More boot info ([#15](https://github.com/rcore-os/pie-boot/pull/15))
+
 ## [0.1.11](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.10...pie-boot-loader-aarch64-v0.1.11) - 2025-06-17
 
 ### Added

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.11"
+version = "0.1.12"
 
 [features]
 console = ["dep:any-uart"]

--- a/pie-boot-if/CHANGELOG.md
+++ b/pie-boot-if/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.3.0...pie-boot-if-v0.4.0) - 2025-06-19
+
+### Other
+
+- More boot info ([#15](https://github.com/rcore-os/pie-boot/pull/15))
+
 ## [0.3.0](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.2.0...pie-boot-if-v0.3.0) - 2025-06-17
 
 ### Added

--- a/pie-boot-if/Cargo.toml
+++ b/pie-boot-if/Cargo.toml
@@ -7,6 +7,6 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-if"
 repository.workspace = true
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.1.11...pie-boot-v0.1.12) - 2025-06-19
+
+### Other
+
+- More boot info ([#15](https://github.com/rcore-os/pie-boot/pull/15))
+
 ## [0.1.11](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.1.10...pie-boot-v0.1.11) - 2025-06-17
 
 ### Other

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.1.11"
+version = "0.1.12"
 
 [features]
 hv = []
@@ -22,7 +22,7 @@ pie-boot-macros = {workspace = true}
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 kasm-aarch64 = {workspace = true}
-pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.11"}
+pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.12" }
 
 [build-dependencies]
 bindeps-simple = {version = "0.2"}


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-if`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `pie-boot-loader-aarch64`: 0.1.11 -> 0.1.12 (✓ API compatible changes)
* `pie-boot`: 0.1.11 -> 0.1.12 (✓ API compatible changes)

### ⚠ `pie-boot-if` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct pie_boot_if::BootArgs, previously in file /tmp/.tmplBmNB7/pie-boot-if/src/lib.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-if`

<blockquote>

## [0.4.0](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.3.0...pie-boot-if-v0.4.0) - 2025-06-19

### Other

- More boot info ([#15](https://github.com/rcore-os/pie-boot/pull/15))
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.12](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.11...pie-boot-loader-aarch64-v0.1.12) - 2025-06-19

### Other

- More boot info ([#15](https://github.com/rcore-os/pie-boot/pull/15))
</blockquote>

## `pie-boot`

<blockquote>

## [0.1.12](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.1.11...pie-boot-v0.1.12) - 2025-06-19

### Other

- More boot info ([#15](https://github.com/rcore-os/pie-boot/pull/15))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).