### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "kdef-pgtable"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitflags",
  "prettyplease",
@@ -1002,7 +1002,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bindeps-simple",
  "fdt-parser",
@@ -1016,11 +1016,11 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-if"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "aarch64-cpu",
  "any-uart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ version = "0.1.0"
 [workspace.dependencies]
 kasm-aarch64 = {path = "macros/kasm-aarch64", version = "0.1"}
 kdef-pgtable = {path = "kdef-pgtable", version = "0.1"}
-pie-boot-if = {path = "pie-boot-if", version = "0.4.0" }
+pie-boot-if = {path = "pie-boot-if", version = "0.4.1" }
 pie-boot-loader-macros = {path = "loader/pie-boot-loader-macros", version = "0.1"}
 pie-boot-macros = {path = "macros/pie-boot-macros", version = "0.1"}

--- a/kdef-pgtable/CHANGELOG.md
+++ b/kdef-pgtable/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.1...kdef-pgtable-v0.1.2) - 2025-06-20
+
+### Added
+
+- enhance boot information structure and debug console initialization
+
 ## [0.1.1](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.0...kdef-pgtable-v0.1.1) - 2025-06-14
 
 ### Other

--- a/kdef-pgtable/Cargo.toml
+++ b/kdef-pgtable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kdef-pgtable"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors.workspace = true
 categories.workspace = true

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.12...pie-boot-loader-aarch64-v0.1.13) - 2025-06-20
+
+### Added
+
+- enhance boot information structure and debug console initialization
+
 ## [0.1.12](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.11...pie-boot-loader-aarch64-v0.1.12) - 2025-06-19
 
 ### Other

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.12"
+version = "0.1.13"
 
 [features]
 console = ["dep:any-uart"]

--- a/pie-boot-if/CHANGELOG.md
+++ b/pie-boot-if/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.4.0...pie-boot-if-v0.4.1) - 2025-06-20
+
+### Added
+
+- enhance boot information structure and debug console initialization
+
 ## [0.4.0](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.3.0...pie-boot-if-v0.4.0) - 2025-06-19
 
 ### Other

--- a/pie-boot-if/Cargo.toml
+++ b/pie-boot-if/Cargo.toml
@@ -7,6 +7,6 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-if"
 repository.workspace = true
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.2...pie-boot-v0.2.3) - 2025-06-20
+
+### Other
+
+- updated the following local packages: pie-boot-if, pie-boot-loader-aarch64
+
 ## [0.2.2](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.1...pie-boot-v0.2.2) - 2025-06-19
 
 ### Other

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.2.2"
+version = "0.2.3"
 
 [features]
 hv = []
@@ -21,7 +21,7 @@ pie-boot-macros = {workspace = true}
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 kasm-aarch64 = {workspace = true}
-pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.12"}
+pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.13" }
 
 [build-dependencies]
 bindeps-simple = {version = "0.2"}


### PR DESCRIPTION



## 🤖 New release

* `kdef-pgtable`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `pie-boot-if`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `pie-boot-loader-aarch64`: 0.1.12 -> 0.1.13 (✓ API compatible changes)
* `pie-boot`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `kdef-pgtable`

<blockquote>

## [0.1.2](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.1...kdef-pgtable-v0.1.2) - 2025-06-20

### Added

- enhance boot information structure and debug console initialization
</blockquote>

## `pie-boot-if`

<blockquote>

## [0.4.1](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.4.0...pie-boot-if-v0.4.1) - 2025-06-20

### Added

- enhance boot information structure and debug console initialization
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.13](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.12...pie-boot-loader-aarch64-v0.1.13) - 2025-06-20

### Added

- enhance boot information structure and debug console initialization
</blockquote>

## `pie-boot`

<blockquote>

## [0.2.3](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.2...pie-boot-v0.2.3) - 2025-06-20

### Other

- updated the following local packages: pie-boot-if, pie-boot-loader-aarch64
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).