### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bindeps-simple",
  "fdt-parser",
@@ -1020,7 +1020,7 @@ version = "0.4.1"
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "aarch64-cpu",
  "any-uart",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.13...pie-boot-loader-aarch64-v0.1.14) - 2025-06-20
+
+### Added
+
+- enhance Pte creation with cache handling and add NoCache variant to CacheKind
+
+### Fixed
+
+- change PTE cache kind to NoCache in new_boot_table function
+
 ## [0.1.13](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.12...pie-boot-loader-aarch64-v0.1.13) - 2025-06-20
 
 ### Added

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.13"
+version = "0.1.14"
 
 [features]
 console = ["dep:any-uart"]

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.4...pie-boot-v0.2.5) - 2025-06-20
+
+### Other
+
+- updated the following local packages: pie-boot-loader-aarch64
+
 ## [0.2.4](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.3...pie-boot-v0.2.4) - 2025-06-20
 
 ### Other

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.2.4"
+version = "0.2.5"
 
 [features]
 hv = []
@@ -21,7 +21,7 @@ pie-boot-macros = {workspace = true}
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 kasm-aarch64 = {workspace = true}
-pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.13" }
+pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.14" }
 
 [build-dependencies]
 bindeps-simple = {version = "0.2"}


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-loader-aarch64`: 0.1.13 -> 0.1.14 (✓ API compatible changes)
* `pie-boot`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.14](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.13...pie-boot-loader-aarch64-v0.1.14) - 2025-06-20

### Added

- enhance Pte creation with cache handling and add NoCache variant to CacheKind

### Fixed

- change PTE cache kind to NoCache in new_boot_table function
</blockquote>

## `pie-boot`

<blockquote>

## [0.2.5](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.4...pie-boot-v0.2.5) - 2025-06-20

### Other

- updated the following local packages: pie-boot-loader-aarch64
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).