### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bindeps-simple",
  "fdt-parser",
@@ -1016,14 +1016,14 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-if"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "heapless",
 ]
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "aarch64-cpu",
  "any-uart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ version = "0.1.0"
 [workspace.dependencies]
 kasm-aarch64 = {path = "macros/kasm-aarch64", version = "0.1"}
 kdef-pgtable = {path = "kdef-pgtable", version = "0.1"}
-pie-boot-if = {path = "pie-boot-if", version = "0.4.1" }
+pie-boot-if = {path = "pie-boot-if", version = "0.5.0" }
 pie-boot-loader-macros = {path = "loader/pie-boot-loader-macros", version = "0.1"}
 pie-boot-macros = {path = "macros/pie-boot-macros", version = "0.1"}

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.14...pie-boot-loader-aarch64-v0.1.15) - 2025-06-25
+
+### Added
+
+- add setup_debugcon function and enhance BootInfo structure with debug console support
+
 ## [0.1.14](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.13...pie-boot-loader-aarch64-v0.1.14) - 2025-06-20
 
 ### Added

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.14"
+version = "0.1.15"
 
 [features]
 console = ["dep:any-uart"]

--- a/pie-boot-if/CHANGELOG.md
+++ b/pie-boot-if/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.4.1...pie-boot-if-v0.5.0) - 2025-06-25
+
+### Added
+
+- add setup_debugcon function and enhance BootInfo structure with debug console support
+
 ## [0.4.1](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.4.0...pie-boot-if-v0.4.1) - 2025-06-20
 
 ### Added

--- a/pie-boot-if/Cargo.toml
+++ b/pie-boot-if/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-if"
 repository.workspace = true
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 heapless = "0.8"

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.5...pie-boot-v0.2.6) - 2025-06-25
+
+### Added
+
+- add setup_debugcon function and enhance BootInfo structure with debug console support
+
 ## [0.2.5](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.4...pie-boot-v0.2.5) - 2025-06-20
 
 ### Other

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.2.5"
+version = "0.2.6"
 
 [features]
 hv = []
@@ -21,7 +21,7 @@ pie-boot-macros = {workspace = true}
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 kasm-aarch64 = {workspace = true}
-pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.14" }
+pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.15" }
 
 [build-dependencies]
 bindeps-simple = {version = "0.2"}


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-if`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `pie-boot-loader-aarch64`: 0.1.14 -> 0.1.15 (✓ API compatible changes)
* `pie-boot`: 0.2.5 -> 0.2.6 (✓ API compatible changes)

### ⚠ `pie-boot-if` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BootInfo.debug_console in /tmp/.tmpyZJVSN/pie-boot/pie-boot-if/src/lib.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-if`

<blockquote>

## [0.5.0](https://github.com/rcore-os/pie-boot/compare/pie-boot-if-v0.4.1...pie-boot-if-v0.5.0) - 2025-06-25

### Added

- add setup_debugcon function and enhance BootInfo structure with debug console support
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.15](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.14...pie-boot-loader-aarch64-v0.1.15) - 2025-06-25

### Added

- add setup_debugcon function and enhance BootInfo structure with debug console support
</blockquote>

## `pie-boot`

<blockquote>

## [0.2.6](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.5...pie-boot-v0.2.6) - 2025-06-25

### Added

- add setup_debugcon function and enhance BootInfo structure with debug console support
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).