### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,7 +1002,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "bindeps-simple",
  "fdt-parser",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "aarch64-cpu",
  "any-uart",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.17...pie-boot-loader-aarch64-v0.1.18) - 2025-07-01
+
+### Added
+
+- skip zero-sized memory regions in FDT setup
+
 ## [0.1.17](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.16...pie-boot-loader-aarch64-v0.1.17) - 2025-06-26
 
 ### Added

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.17"
+version = "0.1.18"
 
 [features]
 console = ["dep:any-uart"]

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.10...pie-boot-v0.2.11) - 2025-07-01
+
+### Added
+
+- skip zero-sized memory regions in FDT setup
+
 ## [0.2.10](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.9...pie-boot-v0.2.10) - 2025-06-27
 
 ### Other

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.2.10"
+version = "0.2.11"
 
 [features]
 hv = []
@@ -21,7 +21,7 @@ pie-boot-macros = {workspace = true}
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 kasm-aarch64 = {workspace = true}
-pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.17" }
+pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.18" }
 
 [build-dependencies]
 bindeps-simple = {version = "0.2"}


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-loader-aarch64`: 0.1.17 -> 0.1.18 (✓ API compatible changes)
* `pie-boot`: 0.2.10 -> 0.2.11 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.18](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.17...pie-boot-loader-aarch64-v0.1.18) - 2025-07-01

### Added

- skip zero-sized memory regions in FDT setup
</blockquote>

## `pie-boot`

<blockquote>

## [0.2.11](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.10...pie-boot-v0.2.11) - 2025-07-01

### Added

- skip zero-sized memory regions in FDT setup
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).