### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.23](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.22...pie-boot-loader-aarch64-v0.1.23) - 2025-07-08
+
+### Added
+
+- add AArch64 support with new register handling and memory setup functions
+
 ## [0.1.22](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.21...pie-boot-loader-aarch64-v0.1.22) - 2025-07-07
 
 ### Fixed

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.22"
+version = "0.1.23"
 
 [features]
 console = ["dep:any-uart"]

--- a/macros/pie-boot-macros/CHANGELOG.md
+++ b/macros/pie-boot-macros/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/rcore-os/pie-boot/compare/pie-boot-macros-v0.1.1...pie-boot-macros-v0.1.2) - 2025-07-08
+
+### Added
+
+- add AArch64 support with new register handling and memory setup functions
+
 ## [0.1.1](https://github.com/rcore-os/pie-boot/compare/pie-boot-macros-v0.1.0...pie-boot-macros-v0.1.1) - 2025-06-14
 
 ### Other

--- a/macros/pie-boot-macros/Cargo.toml
+++ b/macros/pie-boot-macros/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [lib]
 proc-macro = true

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.17](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.16...pie-boot-v0.2.17) - 2025-07-08
+
+### Added
+
+- add AArch64 support with new register handling and memory setup functions
+
 ## [0.2.16](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.15...pie-boot-v0.2.16) - 2025-07-07
 
 ### Other

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.2.16"
+version = "0.2.17"
 
 [features]
 hv = []
@@ -23,7 +23,7 @@ pie-boot-macros = {workspace = true}
 aarch64-cpu = "10.0"
 aarch64-cpu-ext = "0.1"
 kasm-aarch64 = {workspace = true}
-pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.22"}
+pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.23" }
 
 [build-dependencies]
 bindeps-simple = {version = "0.2"}


### PR DESCRIPTION



## 🤖 New release

* `pie-boot-macros`: 0.1.1 -> 0.1.2
* `pie-boot-loader-aarch64`: 0.1.22 -> 0.1.23 (✓ API compatible changes)
* `pie-boot`: 0.2.16 -> 0.2.17 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `pie-boot-macros`

<blockquote>

## [0.1.2](https://github.com/rcore-os/pie-boot/compare/pie-boot-macros-v0.1.1...pie-boot-macros-v0.1.2) - 2025-07-08

### Added

- add AArch64 support with new register handling and memory setup functions
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.23](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.22...pie-boot-loader-aarch64-v0.1.23) - 2025-07-08

### Added

- add AArch64 support with new register handling and memory setup functions
</blockquote>

## `pie-boot`

<blockquote>

## [0.2.17](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.16...pie-boot-v0.2.17) - 2025-07-08

### Added

- add AArch64 support with new register handling and memory setup functions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).