### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "kdef-pgtable"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bitflags",
  "prettyplease",
@@ -1012,7 +1012,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "pie-boot-loader-aarch64"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/kdef-pgtable/CHANGELOG.md
+++ b/kdef-pgtable/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.2...kdef-pgtable-v0.1.3) - 2025-07-08
+
+### Added
+
+- 添加对 AArch64 EL2 的支持
+
 ## [0.1.2](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.1...kdef-pgtable-v0.1.2) - 2025-06-20
 
 ### Added

--- a/kdef-pgtable/Cargo.toml
+++ b/kdef-pgtable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kdef-pgtable"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 categories.workspace = true

--- a/loader/pie-boot-loader-aarch64/CHANGELOG.md
+++ b/loader/pie-boot-loader-aarch64/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.24](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.23...pie-boot-loader-aarch64-v0.1.24) - 2025-07-08
+
+### Added
+
+- 添加对 AArch64 EL2 的支持
+
 ## [0.1.23](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.22...pie-boot-loader-aarch64-v0.1.23) - 2025-07-08
 
 ### Added

--- a/loader/pie-boot-loader-aarch64/Cargo.toml
+++ b/loader/pie-boot-loader-aarch64/Cargo.toml
@@ -10,7 +10,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot-loader-aarch64"
 repository.workspace = true
-version = "0.1.23"
+version = "0.1.24"
 
 [features]
 console = ["dep:any-uart"]

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.18](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.17...pie-boot-v0.2.18) - 2025-07-08
+
+### Added
+
+- 添加对 AArch64 EL2 的支持
+
 ## [0.2.17](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.16...pie-boot-v0.2.17) - 2025-07-08
 
 ### Added

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.2.17"
+version = "0.2.18"
 
 [features]
 hv = ["pie-boot-loader-aarch64/el2"]
@@ -23,7 +23,7 @@ pie-boot-macros = {workspace = true}
 aarch64-cpu = "10.0"
 aarch64-cpu-ext = "0.1"
 kasm-aarch64 = {workspace = true}
-pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.23" }
+pie-boot-loader-aarch64 = {path = "../loader/pie-boot-loader-aarch64", version = "0.1.24" }
 
 [build-dependencies]
 bindeps-simple = {version = "0.2"}


### PR DESCRIPTION



## 🤖 New release

* `kdef-pgtable`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `pie-boot-loader-aarch64`: 0.1.23 -> 0.1.24 (✓ API compatible changes)
* `pie-boot`: 0.2.17 -> 0.2.18 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `kdef-pgtable`

<blockquote>

## [0.1.3](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.2...kdef-pgtable-v0.1.3) - 2025-07-08

### Added

- 添加对 AArch64 EL2 的支持
</blockquote>

## `pie-boot-loader-aarch64`

<blockquote>

## [0.1.24](https://github.com/rcore-os/pie-boot/compare/pie-boot-loader-aarch64-v0.1.23...pie-boot-loader-aarch64-v0.1.24) - 2025-07-08

### Added

- 添加对 AArch64 EL2 的支持
</blockquote>

## `pie-boot`

<blockquote>

## [0.2.18](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.17...pie-boot-v0.2.18) - 2025-07-08

### Added

- 添加对 AArch64 EL2 的支持
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).