### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "kdef-pgtable"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bitflags",
  "prettyplease",
@@ -1012,7 +1012,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pie-boot"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "aarch64-cpu",
  "aarch64-cpu-ext",

--- a/kdef-pgtable/CHANGELOG.md
+++ b/kdef-pgtable/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.3...kdef-pgtable-v0.1.4) - 2025-07-08
+
+### Added
+
+- 更新 KIMAGE_VSIZE 常量并在 Cargo.toml 中添加 kdef-pgtable/space-low 特性
+
+### Other
+
+- Merge branch 'master' of github.com:rcore-os/pie-boot
+
 ## [0.1.3](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.2...kdef-pgtable-v0.1.3) - 2025-07-08
 
 ### Added

--- a/kdef-pgtable/Cargo.toml
+++ b/kdef-pgtable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kdef-pgtable"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 categories.workspace = true

--- a/pie-boot/CHANGELOG.md
+++ b/pie-boot/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.19](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.18...pie-boot-v0.2.19) - 2025-07-08
+
+### Added
+
+- 更新 KIMAGE_VSIZE 常量并在 Cargo.toml 中添加 kdef-pgtable/space-low 特性
+
+### Other
+
+- Merge branch 'master' of github.com:rcore-os/pie-boot
+
 ## [0.2.18](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.17...pie-boot-v0.2.18) - 2025-07-08
 
 ### Added

--- a/pie-boot/Cargo.toml
+++ b/pie-boot/Cargo.toml
@@ -7,7 +7,7 @@ keywords.workspace = true
 license.workspace = true
 name = "pie-boot"
 repository.workspace = true
-version = "0.2.18"
+version = "0.2.19"
 
 [features]
 hv = ["pie-boot-loader-aarch64/el2", "kdef-pgtable/space-low"]


### PR DESCRIPTION



## 🤖 New release

* `kdef-pgtable`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `pie-boot`: 0.2.18 -> 0.2.19 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `kdef-pgtable`

<blockquote>

## [0.1.4](https://github.com/rcore-os/pie-boot/compare/kdef-pgtable-v0.1.3...kdef-pgtable-v0.1.4) - 2025-07-08

### Added

- 更新 KIMAGE_VSIZE 常量并在 Cargo.toml 中添加 kdef-pgtable/space-low 特性

### Other

- Merge branch 'master' of github.com:rcore-os/pie-boot
</blockquote>

## `pie-boot`

<blockquote>

## [0.2.19](https://github.com/rcore-os/pie-boot/compare/pie-boot-v0.2.18...pie-boot-v0.2.19) - 2025-07-08

### Added

- 更新 KIMAGE_VSIZE 常量并在 Cargo.toml 中添加 kdef-pgtable/space-low 特性

### Other

- Merge branch 'master' of github.com:rcore-os/pie-boot
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).